### PR TITLE
Comparision-Implementation

### DIFF
--- a/source/GlmNet/GlmNet/mat2.cs
+++ b/source/GlmNet/GlmNet/mat2.cs
@@ -3,168 +3,215 @@ using System.Linq;
 
 namespace GlmNet
 {
-    /// <summary>
-    /// Represents a 2x2 matrix.
-    /// </summary>
-    public struct mat2
-    {
-        #region Construction
+  /// <summary>
+  /// Represents a 2x2 matrix.
+  /// </summary>
+  public struct mat2
+  {
+    #region Construction
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="mat2"/> struct.
-        /// This matrix is the identity matrix scaled by <paramref name="scale"/>.
-        /// </summary>
-        /// <param name="scale">The scale.</param>
-        public mat2(float scale)
-        {
-            cols = new[]
-            {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="mat2"/> struct.
+    /// This matrix is the identity matrix scaled by <paramref name="scale"/>.
+    /// </summary>
+    /// <param name="scale">The scale.</param>
+    public mat2(float scale)
+    {
+      cols = new[]
+      {
                 new vec2(scale, 0.0f),
                 new vec2(0.0f, scale)
             };
-        }
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="mat2"/> struct.
-        /// The matrix is initialised with the <paramref name="cols"/>.
-        /// </summary>
-        /// <param name="cols">The colums of the matrix.</param>
-        public mat2(vec2[] cols)
-        {
-            this.cols = new[]
-            {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="mat2"/> struct.
+    /// The matrix is initialised with the <paramref name="cols"/>.
+    /// </summary>
+    /// <param name="cols">The colums of the matrix.</param>
+    public mat2(vec2[] cols)
+    {
+      this.cols = new[]
+      {
                 cols[0],
                 cols[1]
             };
-        }
+    }
 
-        public mat2(vec2 a, vec2 b)
-        {
-            this.cols = new[]
-            {
+    public mat2(vec2 a, vec2 b)
+    {
+      this.cols = new[]
+      {
                 a, b
             };
-        }
+    }
 
-        public mat2(float a, float b, float c, float d)
-        {
-            this.cols = new[]
-            {
+    public mat2(float a, float b, float c, float d)
+    {
+      this.cols = new[]
+      {
                 new vec2(a,b), new vec2(c,d)
             };
-        }
+    }
 
-        /// <summary>
-        /// Creates an identity matrix.
-        /// </summary>
-        /// <returns>A new identity matrix.</returns>
-        public static mat2 identity()
-        {
-            return new mat2
-            {
-                cols = new[] 
-                {
+    /// <summary>
+    /// Creates an identity matrix.
+    /// </summary>
+    /// <returns>A new identity matrix.</returns>
+    public static mat2 identity()
+    {
+      return new mat2
+      {
+        cols = new[]
+          {
                     new vec2(1,0),
                     new vec2(0,1)
                 }
-            };
-        }
+      };
+    }
 
-        #endregion
+    #endregion
 
-        #region Index Access
+    #region Index Access
 
-        /// <summary>
-        /// Gets or sets the <see cref="vec2"/> column at the specified index.
-        /// </summary>
-        /// <value>
-        /// The <see cref="vec2"/> column.
-        /// </value>
-        /// <param name="column">The column index.</param>
-        /// <returns>The column at index <paramref name="column"/>.</returns>
-        public vec2 this[int column]
-        {
-            get { return cols[column]; }
-            set { cols[column] = value; }
-        }
+    /// <summary>
+    /// Gets or sets the <see cref="vec2"/> column at the specified index.
+    /// </summary>
+    /// <value>
+    /// The <see cref="vec2"/> column.
+    /// </value>
+    /// <param name="column">The column index.</param>
+    /// <returns>The column at index <paramref name="column"/>.</returns>
+    public vec2 this[int column]
+    {
+      get { return cols[column]; }
+      set { cols[column] = value; }
+    }
 
-        /// <summary>
-        /// Gets or sets the element at <paramref name="column"/> and <paramref name="row"/>.
-        /// </summary>
-        /// <value>
-        /// The element at <paramref name="column"/> and <paramref name="row"/>.
-        /// </value>
-        /// <param name="column">The column index.</param>
-        /// <param name="row">The row index.</param>
-        /// <returns>
-        /// The element at <paramref name="column"/> and <paramref name="row"/>.
-        /// </returns>
-        public float this[int column, int row]
-        {
-            get { return cols[column][row]; }
-            set { cols[column][row] = value; }
-        }
+    /// <summary>
+    /// Gets or sets the element at <paramref name="column"/> and <paramref name="row"/>.
+    /// </summary>
+    /// <value>
+    /// The element at <paramref name="column"/> and <paramref name="row"/>.
+    /// </value>
+    /// <param name="column">The column index.</param>
+    /// <param name="row">The row index.</param>
+    /// <returns>
+    /// The element at <paramref name="column"/> and <paramref name="row"/>.
+    /// </returns>
+    public float this[int column, int row]
+    {
+      get { return cols[column][row]; }
+      set { cols[column][row] = value; }
+    }
 
-        #endregion
+    #endregion
 
-        #region Conversion
+    #region Conversion
 
-        /// <summary>
-        /// Returns the matrix as a flat array of elements, column major.
-        /// </summary>
-        /// <returns></returns>
-        public float[] to_array()
-        {
-            return cols.SelectMany(v => v.to_array()).ToArray();
-        }
+    /// <summary>
+    /// Returns the matrix as a flat array of elements, column major.
+    /// </summary>
+    /// <returns></returns>
+    public float[] to_array()
+    {
+      return cols.SelectMany(v => v.to_array()).ToArray();
+    }
 
-        #endregion
+    #endregion
 
-        #region Multiplication
+    #region Multiplication
 
-        /// <summary>
-        /// Multiplies the <paramref name="lhs"/> matrix by the <paramref name="rhs"/> vector.
-        /// </summary>
-        /// <param name="lhs">The LHS matrix.</param>
-        /// <param name="rhs">The RHS vector.</param>
-        /// <returns>The product of <paramref name="lhs"/> and <paramref name="rhs"/>.</returns>
-        public static vec2 operator *(mat2 lhs, vec2 rhs)
-        {
-            return new vec2(
-                lhs[0,0] * rhs[0] + lhs[1,0] * rhs[1], 
-                lhs[0,1] * rhs[0] + lhs[1,1] * rhs[1]
-            );
-        }
+    /// <summary>
+    /// Multiplies the <paramref name="lhs"/> matrix by the <paramref name="rhs"/> vector.
+    /// </summary>
+    /// <param name="lhs">The LHS matrix.</param>
+    /// <param name="rhs">The RHS vector.</param>
+    /// <returns>The product of <paramref name="lhs"/> and <paramref name="rhs"/>.</returns>
+    public static vec2 operator *(mat2 lhs, vec2 rhs)
+    {
+      return new vec2(
+          lhs[0, 0] * rhs[0] + lhs[1, 0] * rhs[1],
+          lhs[0, 1] * rhs[0] + lhs[1, 1] * rhs[1]
+      );
+    }
 
-        /// <summary>
-        /// Multiplies the <paramref name="lhs"/> matrix by the <paramref name="rhs"/> matrix.
-        /// </summary>
-        /// <param name="lhs">The LHS matrix.</param>
-        /// <param name="rhs">The RHS matrix.</param>
-        /// <returns>The product of <paramref name="lhs"/> and <paramref name="rhs"/>.</returns>
-        public static mat2 operator *(mat2 lhs, mat2 rhs)
-        {
-            return new mat2(new[]
-            {
-			    lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1],
-			    lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1]
+    /// <summary>
+    /// Multiplies the <paramref name="lhs"/> matrix by the <paramref name="rhs"/> matrix.
+    /// </summary>
+    /// <param name="lhs">The LHS matrix.</param>
+    /// <param name="rhs">The RHS matrix.</param>
+    /// <returns>The product of <paramref name="lhs"/> and <paramref name="rhs"/>.</returns>
+    public static mat2 operator *(mat2 lhs, mat2 rhs)
+    {
+      return new mat2(new[]
+      {
+          lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1],
+          lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1]
             });
-        }
+    }
 
-        public static mat2 operator * (mat2 lhs, float s)
-        {
-            return new mat2(new[]
-            {
+    public static mat2 operator *(mat2 lhs, float s)
+    {
+      return new mat2(new[]
+      {
                 lhs[0]*s,
                 lhs[1]*s
             });
-        }
-
-        #endregion
-
-        /// <summary>
-        /// The columms of the matrix.
-        /// </summary>
-        private vec2[] cols;
     }
+
+    #endregion
+
+    #region comparision
+    /// <summary>
+    /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+    /// The Difference is detected by the different values
+    /// </summary>
+    /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+    /// </returns>
+    public override bool Equals(object obj)
+    {
+      if (obj.GetType() == typeof(mat2))
+      {
+        var mat = (mat2)obj;
+        if (mat[0] == this[0] && mat[1] == this[1])
+          return true;
+      }
+
+      return false;
+    }
+    /// <summary>
+    /// Implements the operator ==.
+    /// </summary>
+    /// <param name="m1">The first Matrix.</param>
+    /// <param name="m2">The second Matrix.</param>
+    /// <returns>
+    /// The result of the operator.
+    /// </returns>
+    public static bool operator ==(mat2 m1, mat2 m2)
+    {
+      return m1.Equals(m2);
+    }
+
+    /// <summary>
+    /// Implements the operator !=.
+    /// </summary>
+    /// <param name="m1">The first Matrix.</param>
+    /// <param name="m2">The second Matrix.</param>
+    /// <returns>
+    /// The result of the operator.
+    /// </returns>
+    public static bool operator !=(mat2 m1, mat2 m2)
+    {
+      return !m1.Equals(m2);
+    }
+    #endregion
+
+    /// <summary>
+    /// The columms of the matrix.
+    /// </summary>
+    private vec2[] cols;
+  }
 }

--- a/source/GlmNet/GlmNet/mat2.cs
+++ b/source/GlmNet/GlmNet/mat2.cs
@@ -207,6 +207,17 @@ namespace GlmNet
     {
       return !m1.Equals(m2);
     }
+
+    /// <summary>
+    /// Returns a hash code for this instance.
+    /// </summary>
+    /// <returns>
+    /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+    /// </returns>
+    public override int GetHashCode()
+    {
+      return this[0].GetHashCode() ^ this[1].GetHashCode();
+    }
     #endregion
 
     /// <summary>

--- a/source/GlmNet/GlmNet/mat3.cs
+++ b/source/GlmNet/GlmNet/mat3.cs
@@ -216,6 +216,17 @@ namespace GlmNet
     {
       return !m1.Equals(m2);
     }
+
+    /// <summary>
+    /// Returns a hash code for this instance.
+    /// </summary>
+    /// <returns>
+    /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+    /// </returns>
+    public override int GetHashCode()
+    {
+      return this[0].GetHashCode() ^ this[1].GetHashCode() ^ this[2].GetHashCode();
+    }
     #endregion
 
     /// <summary>

--- a/source/GlmNet/GlmNet/mat3.cs
+++ b/source/GlmNet/GlmNet/mat3.cs
@@ -1,179 +1,226 @@
 using System;
 using System.Linq;
 
-namespace GlmNet 
+namespace GlmNet
 {
-    /// <summary>
-    /// Represents a 3x3 matrix.
-    /// </summary>
-    public struct mat3
-    {
-        #region Construction
+  /// <summary>
+  /// Represents a 3x3 matrix.
+  /// </summary>
+  public struct mat3
+  {
+    #region Construction
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="mat3"/> struct.
-        /// This matrix is the identity matrix scaled by <paramref name="scale"/>.
-        /// </summary>
-        /// <param name="scale">The scale.</param>
-        public mat3(float scale)
-        {
-            cols = new[]
-            {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="mat3"/> struct.
+    /// This matrix is the identity matrix scaled by <paramref name="scale"/>.
+    /// </summary>
+    /// <param name="scale">The scale.</param>
+    public mat3(float scale)
+    {
+      cols = new[]
+      {
                 new vec3(scale, 0.0f, 0.0f),
                 new vec3(0.0f, scale, 0.0f),
                 new vec3(0.0f, 0.0f, scale)
             };
-        }
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="mat3"/> struct.
-        /// The matrix is initialised with the <paramref name="cols"/>.
-        /// </summary>
-        /// <param name="cols">The colums of the matrix.</param>
-        public mat3(vec3[] cols)
-        {
-            this.cols = new[]
-            {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="mat3"/> struct.
+    /// The matrix is initialised with the <paramref name="cols"/>.
+    /// </summary>
+    /// <param name="cols">The colums of the matrix.</param>
+    public mat3(vec3[] cols)
+    {
+      this.cols = new[]
+      {
                 cols[0],
                 cols[1],
                 cols[2]
             };
-        }
+    }
 
-        public mat3(vec3 a, vec3 b, vec3 c)
-        {
-            this.cols = new[]
-            {
+    public mat3(vec3 a, vec3 b, vec3 c)
+    {
+      this.cols = new[]
+      {
                 a, b, c
             };
-        }
+    }
 
-        /// <summary>
-        /// Creates an identity matrix.
-        /// </summary>
-        /// <returns>A new identity matrix.</returns>
-        public static mat3 identity()
-        {
-            return new mat3
-            {
-                cols = new[] 
-                {
+    /// <summary>
+    /// Creates an identity matrix.
+    /// </summary>
+    /// <returns>A new identity matrix.</returns>
+    public static mat3 identity()
+    {
+      return new mat3
+      {
+        cols = new[]
+          {
                     new vec3(1,0,0),
                     new vec3(0,1,0),
                     new vec3(0,0,1)
                 }
-            };
-        }
+      };
+    }
 
-        #endregion
+    #endregion
 
-        #region Index Access
+    #region Index Access
 
-        /// <summary>
-        /// Gets or sets the <see cref="vec3"/> column at the specified index.
-        /// </summary>
-        /// <value>
-        /// The <see cref="vec3"/> column.
-        /// </value>
-        /// <param name="column">The column index.</param>
-        /// <returns>The column at index <paramref name="column"/>.</returns>
-        public vec3 this[int column]
-        {
-            get { return cols[column]; }
-            set { cols[column] = value; }
-        }
+    /// <summary>
+    /// Gets or sets the <see cref="vec3"/> column at the specified index.
+    /// </summary>
+    /// <value>
+    /// The <see cref="vec3"/> column.
+    /// </value>
+    /// <param name="column">The column index.</param>
+    /// <returns>The column at index <paramref name="column"/>.</returns>
+    public vec3 this[int column]
+    {
+      get { return cols[column]; }
+      set { cols[column] = value; }
+    }
 
-        /// <summary>
-        /// Gets or sets the element at <paramref name="column"/> and <paramref name="row"/>.
-        /// </summary>
-        /// <value>
-        /// The element at <paramref name="column"/> and <paramref name="row"/>.
-        /// </value>
-        /// <param name="column">The column index.</param>
-        /// <param name="row">The row index.</param>
-        /// <returns>
-        /// The element at <paramref name="column"/> and <paramref name="row"/>.
-        /// </returns>
-        public float this[int column, int row]
-        {
-            get { return cols[column][row]; }
-            set { cols[column][row] = value; }
-        }
+    /// <summary>
+    /// Gets or sets the element at <paramref name="column"/> and <paramref name="row"/>.
+    /// </summary>
+    /// <value>
+    /// The element at <paramref name="column"/> and <paramref name="row"/>.
+    /// </value>
+    /// <param name="column">The column index.</param>
+    /// <param name="row">The row index.</param>
+    /// <returns>
+    /// The element at <paramref name="column"/> and <paramref name="row"/>.
+    /// </returns>
+    public float this[int column, int row]
+    {
+      get { return cols[column][row]; }
+      set { cols[column][row] = value; }
+    }
 
-        #endregion
+    #endregion
 
-        #region Conversion
+    #region Conversion
 
-        /// <summary>
-        /// Returns the matrix as a flat array of elements, column major.
-        /// </summary>
-        /// <returns></returns>
-        public float[] to_array()
-        {
-            return cols.SelectMany(v => v.to_array()).ToArray();
-        }
+    /// <summary>
+    /// Returns the matrix as a flat array of elements, column major.
+    /// </summary>
+    /// <returns></returns>
+    public float[] to_array()
+    {
+      return cols.SelectMany(v => v.to_array()).ToArray();
+    }
 
-        /// <summary>
-        /// Returns the <see cref="mat3"/> portion of this matrix.
-        /// </summary>
-        /// <returns>The <see cref="mat3"/> portion of this matrix.</returns>
-        public mat2 to_mat2()
-        {
-            return new mat2(new[] {
-			new vec2(cols[0][0], cols[0][1]),
-			new vec2(cols[1][0], cols[1][1])});
-        }
+    /// <summary>
+    /// Returns the <see cref="mat3"/> portion of this matrix.
+    /// </summary>
+    /// <returns>The <see cref="mat3"/> portion of this matrix.</returns>
+    public mat2 to_mat2()
+    {
+      return new mat2(new[] {
+      new vec2(cols[0][0], cols[0][1]),
+      new vec2(cols[1][0], cols[1][1])});
+    }
 
-        #endregion
+    #endregion
 
-        #region Multiplication
+    #region Multiplication
 
-        /// <summary>
-        /// Multiplies the <paramref name="lhs"/> matrix by the <paramref name="rhs"/> vector.
-        /// </summary>
-        /// <param name="lhs">The LHS matrix.</param>
-        /// <param name="rhs">The RHS vector.</param>
-        /// <returns>The product of <paramref name="lhs"/> and <paramref name="rhs"/>.</returns>
-        public static vec3 operator *(mat3 lhs, vec3 rhs)
-        {
-            return new vec3(
-                lhs[0, 0] * rhs[0] + lhs[1, 0] * rhs[1] + lhs[2, 0] * rhs[2],
-                lhs[0, 1] * rhs[0] + lhs[1, 1] * rhs[1] + lhs[2, 1] * rhs[2],
-                lhs[0, 2] * rhs[0] + lhs[1, 2] * rhs[1] + lhs[2, 2] * rhs[2]
-            );
-        }
+    /// <summary>
+    /// Multiplies the <paramref name="lhs"/> matrix by the <paramref name="rhs"/> vector.
+    /// </summary>
+    /// <param name="lhs">The LHS matrix.</param>
+    /// <param name="rhs">The RHS vector.</param>
+    /// <returns>The product of <paramref name="lhs"/> and <paramref name="rhs"/>.</returns>
+    public static vec3 operator *(mat3 lhs, vec3 rhs)
+    {
+      return new vec3(
+          lhs[0, 0] * rhs[0] + lhs[1, 0] * rhs[1] + lhs[2, 0] * rhs[2],
+          lhs[0, 1] * rhs[0] + lhs[1, 1] * rhs[1] + lhs[2, 1] * rhs[2],
+          lhs[0, 2] * rhs[0] + lhs[1, 2] * rhs[1] + lhs[2, 2] * rhs[2]
+      );
+    }
 
-        /// <summary>
-        /// Multiplies the <paramref name="lhs"/> matrix by the <paramref name="rhs"/> matrix.
-        /// </summary>
-        /// <param name="lhs">The LHS matrix.</param>
-        /// <param name="rhs">The RHS matrix.</param>
-        /// <returns>The product of <paramref name="lhs"/> and <paramref name="rhs"/>.</returns>
-        public static mat3 operator *(mat3 lhs, mat3 rhs)
-        {
-            return new mat3(new[]
-            {
-			    lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1] + lhs[2][0] * rhs[2],
-			    lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1] + lhs[2][1] * rhs[2],
-			    lhs[0][2] * rhs[0] + lhs[1][2] * rhs[1] + lhs[2][2] * rhs[2]
+    /// <summary>
+    /// Multiplies the <paramref name="lhs"/> matrix by the <paramref name="rhs"/> matrix.
+    /// </summary>
+    /// <param name="lhs">The LHS matrix.</param>
+    /// <param name="rhs">The RHS matrix.</param>
+    /// <returns>The product of <paramref name="lhs"/> and <paramref name="rhs"/>.</returns>
+    public static mat3 operator *(mat3 lhs, mat3 rhs)
+    {
+      return new mat3(new[]
+      {
+          lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1] + lhs[2][0] * rhs[2],
+          lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1] + lhs[2][1] * rhs[2],
+          lhs[0][2] * rhs[0] + lhs[1][2] * rhs[1] + lhs[2][2] * rhs[2]
             });
-        }
+    }
 
-        public static mat3 operator * (mat3 lhs, float s)
-        {
-            return new mat3(new[]
-            {
+    public static mat3 operator *(mat3 lhs, float s)
+    {
+      return new mat3(new[]
+      {
                 lhs[0]*s,
                 lhs[1]*s,
                 lhs[2]*s
             });
-        }
-
-        #endregion
-
-        /// <summary>
-        /// The columms of the matrix.
-        /// </summary>
-        private vec3[] cols;
     }
+
+    #endregion
+
+    #region comparision
+    /// <summary>
+    /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+    /// The Difference is detected by the different values
+    /// </summary>
+    /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+    /// </returns>
+    public override bool Equals(object obj)
+    {
+      if (obj.GetType() == typeof(mat3))
+      {
+        var mat = (mat3)obj;
+        if (mat[0] == this[0] && mat[1] == this[1] && mat[2] == this[2])
+          return true;
+      }
+
+      return false;
+    }
+    /// <summary>
+    /// Implements the operator ==.
+    /// </summary>
+    /// <param name="m1">The first Matrix.</param>
+    /// <param name="m2">The second Matrix.</param>
+    /// <returns>
+    /// The result of the operator.
+    /// </returns>
+    public static bool operator ==(mat3 m1, mat3 m2)
+    {
+      return m1.Equals(m2);
+    }
+
+    /// <summary>
+    /// Implements the operator !=.
+    /// </summary>
+    /// <param name="m1">The first Matrix.</param>
+    /// <param name="m2">The second Matrix.</param>
+    /// <returns>
+    /// The result of the operator.
+    /// </returns>
+    public static bool operator !=(mat3 m1, mat3 m2)
+    {
+      return !m1.Equals(m2);
+    }
+    #endregion
+
+    /// <summary>
+    /// The columms of the matrix.
+    /// </summary>
+    private vec3[] cols;
+  }
 }

--- a/source/GlmNet/GlmNet/mat4.cs
+++ b/source/GlmNet/GlmNet/mat4.cs
@@ -1,186 +1,233 @@
 using System;
 using System.Linq;
 
-namespace GlmNet 
+namespace GlmNet
 {
-    /// <summary>
-    /// Represents a 4x4 matrix.
-    /// </summary>
-	public struct mat4
-    {
-        #region Construction
+  /// <summary>
+  /// Represents a 4x4 matrix.
+  /// </summary>
+  public struct mat4
+  {
+    #region Construction
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="mat4"/> struct.
-        /// This matrix is the identity matrix scaled by <paramref name="scale"/>.
-        /// </summary>
-        /// <param name="scale">The scale.</param>
-		public mat4(float scale)
-        {
-            cols = new []
-            {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="mat4"/> struct.
+    /// This matrix is the identity matrix scaled by <paramref name="scale"/>.
+    /// </summary>
+    /// <param name="scale">The scale.</param>
+    public mat4(float scale)
+    {
+      cols = new[]
+      {
                 new vec4(scale, 0.0f, 0.0f, 0.0f),
                 new vec4(0.0f, scale, 0.0f, 0.0f),
                 new vec4(0.0f, 0.0f, scale, 0.0f),
                 new vec4(0.0f, 0.0f, 0.0f, scale),
             };
-        }
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="mat4"/> struct.
-        /// The matrix is initialised with the <paramref name="cols"/>.
-        /// </summary>
-        /// <param name="cols">The colums of the matrix.</param>
-        public mat4(vec4[] cols)
-        {
-            this.cols = new []
-            {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="mat4"/> struct.
+    /// The matrix is initialised with the <paramref name="cols"/>.
+    /// </summary>
+    /// <param name="cols">The colums of the matrix.</param>
+    public mat4(vec4[] cols)
+    {
+      this.cols = new[]
+      {
                 cols[0],
                 cols[1],
                 cols[2],
                 cols[3]
             };
-        }
+    }
 
-        public mat4(vec4 a, vec4 b, vec4 c, vec4 d)
-        {
-            this.cols = new[]
-            {
+    public mat4(vec4 a, vec4 b, vec4 c, vec4 d)
+    {
+      this.cols = new[]
+      {
                 a, b, c, d
             };
-        }
+    }
 
-        /// <summary>
-        /// Creates an identity matrix.
-        /// </summary>
-        /// <returns>A new identity matrix.</returns>
-        public static mat4 identity()
-        {
-            return new mat4
-            {
-                cols = new[] 
-                {
+    /// <summary>
+    /// Creates an identity matrix.
+    /// </summary>
+    /// <returns>A new identity matrix.</returns>
+    public static mat4 identity()
+    {
+      return new mat4
+      {
+        cols = new[]
+          {
                     new vec4(1,0,0,0),
                     new vec4(0,1,0,0),
                     new vec4(0,0,1,0),
                     new vec4(0,0,0,1)
                 }
-            };
-        }
+      };
+    }
 
-        #endregion
+    #endregion
 
-        #region Index Access
+    #region Index Access
 
-        /// <summary>
-        /// Gets or sets the <see cref="vec4"/> column at the specified index.
-        /// </summary>
-        /// <value>
-        /// The <see cref="vec4"/> column.
-        /// </value>
-        /// <param name="column">The column index.</param>
-        /// <returns>The column at index <paramref name="column"/>.</returns>
-        public vec4 this[int column]
-		{
-            get { return cols[column]; }
-            set { cols[column] = value; }
-		}
+    /// <summary>
+    /// Gets or sets the <see cref="vec4"/> column at the specified index.
+    /// </summary>
+    /// <value>
+    /// The <see cref="vec4"/> column.
+    /// </value>
+    /// <param name="column">The column index.</param>
+    /// <returns>The column at index <paramref name="column"/>.</returns>
+    public vec4 this[int column]
+    {
+      get { return cols[column]; }
+      set { cols[column] = value; }
+    }
 
-        /// <summary>
-        /// Gets or sets the element at <paramref name="column"/> and <paramref name="row"/>.
-        /// </summary>
-        /// <value>
-        /// The element at <paramref name="column"/> and <paramref name="row"/>.
-        /// </value>
-        /// <param name="column">The column index.</param>
-        /// <param name="row">The row index.</param>
-        /// <returns>
-        /// The element at <paramref name="column"/> and <paramref name="row"/>.
-        /// </returns>
-        public float this[int column, int row]
-        {
-            get { return cols[column][row]; }
-            set { cols[column][row] = value; }
-        }
+    /// <summary>
+    /// Gets or sets the element at <paramref name="column"/> and <paramref name="row"/>.
+    /// </summary>
+    /// <value>
+    /// The element at <paramref name="column"/> and <paramref name="row"/>.
+    /// </value>
+    /// <param name="column">The column index.</param>
+    /// <param name="row">The row index.</param>
+    /// <returns>
+    /// The element at <paramref name="column"/> and <paramref name="row"/>.
+    /// </returns>
+    public float this[int column, int row]
+    {
+      get { return cols[column][row]; }
+      set { cols[column][row] = value; }
+    }
 
-        #endregion
+    #endregion
 
-        #region Conversion
-        
-        /// <summary>
-        /// Returns the matrix as a flat array of elements, column major.
-        /// </summary>
-        /// <returns></returns>
-        public float[] to_array()
-        {
-            return cols.SelectMany(v => v.to_array()).ToArray();
-        }
+    #region Conversion
 
-        /// <summary>
-        /// Returns the <see cref="mat3"/> portion of this matrix.
-        /// </summary>
-        /// <returns>The <see cref="mat3"/> portion of this matrix.</returns>
-        public mat3 to_mat3()
-        {
-            return new mat3(new[] {
-			new vec3(cols[0][0], cols[0][1], cols[0][2]),
-			new vec3(cols[1][0], cols[1][1], cols[1][2]),
-			new vec3(cols[2][0], cols[2][1], cols[2][2])});
-        }
+    /// <summary>
+    /// Returns the matrix as a flat array of elements, column major.
+    /// </summary>
+    /// <returns></returns>
+    public float[] to_array()
+    {
+      return cols.SelectMany(v => v.to_array()).ToArray();
+    }
 
-        #endregion
+    /// <summary>
+    /// Returns the <see cref="mat3"/> portion of this matrix.
+    /// </summary>
+    /// <returns>The <see cref="mat3"/> portion of this matrix.</returns>
+    public mat3 to_mat3()
+    {
+      return new mat3(new[] {
+      new vec3(cols[0][0], cols[0][1], cols[0][2]),
+      new vec3(cols[1][0], cols[1][1], cols[1][2]),
+      new vec3(cols[2][0], cols[2][1], cols[2][2])});
+    }
 
-        #region Multiplication
+    #endregion
 
-        /// <summary>
-        /// Multiplies the <paramref name="lhs"/> matrix by the <paramref name="rhs"/> vector.
-        /// </summary>
-        /// <param name="lhs">The LHS matrix.</param>
-        /// <param name="rhs">The RHS vector.</param>
-        /// <returns>The product of <paramref name="lhs"/> and <paramref name="rhs"/>.</returns>
-        public static vec4 operator *(mat4 lhs, vec4 rhs)
-        {
-            return new vec4(
-                lhs[0, 0] * rhs[0] + lhs[1, 0] * rhs[1] + lhs[2, 0] * rhs[2] + lhs[3, 0] * rhs[3],
-                lhs[0, 1] * rhs[0] + lhs[1, 1] * rhs[1] + lhs[2, 1] * rhs[2] + lhs[3, 1] * rhs[3],
-                lhs[0, 2] * rhs[0] + lhs[1, 2] * rhs[1] + lhs[2, 2] * rhs[2] + lhs[3, 2] * rhs[3],
-                lhs[0, 3] * rhs[0] + lhs[1, 3] * rhs[1] + lhs[2, 3] * rhs[2] + lhs[3, 3] * rhs[3]
-            );
-        }
+    #region Multiplication
 
-        /// <summary>
-        /// Multiplies the <paramref name="lhs"/> matrix by the <paramref name="rhs"/> matrix.
-        /// </summary>
-        /// <param name="lhs">The LHS matrix.</param>
-        /// <param name="rhs">The RHS matrix.</param>
-        /// <returns>The product of <paramref name="lhs"/> and <paramref name="rhs"/>.</returns>
-        public static mat4 operator * (mat4 lhs, mat4 rhs)
-        {
-            return new mat4(new []
-            {
-			    lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1] + lhs[2][0] * rhs[2] + lhs[3][0] * rhs[3],
-			    lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1] + lhs[2][1] * rhs[2] + lhs[3][1] * rhs[3],
-			    lhs[0][2] * rhs[0] + lhs[1][2] * rhs[1] + lhs[2][2] * rhs[2] + lhs[3][2] * rhs[3],
-			    lhs[0][3] * rhs[0] + lhs[1][3] * rhs[1] + lhs[2][3] * rhs[2] + lhs[3][3] * rhs[3]
+    /// <summary>
+    /// Multiplies the <paramref name="lhs"/> matrix by the <paramref name="rhs"/> vector.
+    /// </summary>
+    /// <param name="lhs">The LHS matrix.</param>
+    /// <param name="rhs">The RHS vector.</param>
+    /// <returns>The product of <paramref name="lhs"/> and <paramref name="rhs"/>.</returns>
+    public static vec4 operator *(mat4 lhs, vec4 rhs)
+    {
+      return new vec4(
+          lhs[0, 0] * rhs[0] + lhs[1, 0] * rhs[1] + lhs[2, 0] * rhs[2] + lhs[3, 0] * rhs[3],
+          lhs[0, 1] * rhs[0] + lhs[1, 1] * rhs[1] + lhs[2, 1] * rhs[2] + lhs[3, 1] * rhs[3],
+          lhs[0, 2] * rhs[0] + lhs[1, 2] * rhs[1] + lhs[2, 2] * rhs[2] + lhs[3, 2] * rhs[3],
+          lhs[0, 3] * rhs[0] + lhs[1, 3] * rhs[1] + lhs[2, 3] * rhs[2] + lhs[3, 3] * rhs[3]
+      );
+    }
+
+    /// <summary>
+    /// Multiplies the <paramref name="lhs"/> matrix by the <paramref name="rhs"/> matrix.
+    /// </summary>
+    /// <param name="lhs">The LHS matrix.</param>
+    /// <param name="rhs">The RHS matrix.</param>
+    /// <returns>The product of <paramref name="lhs"/> and <paramref name="rhs"/>.</returns>
+    public static mat4 operator *(mat4 lhs, mat4 rhs)
+    {
+      return new mat4(new[]
+      {
+          lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1] + lhs[2][0] * rhs[2] + lhs[3][0] * rhs[3],
+          lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1] + lhs[2][1] * rhs[2] + lhs[3][1] * rhs[3],
+          lhs[0][2] * rhs[0] + lhs[1][2] * rhs[1] + lhs[2][2] * rhs[2] + lhs[3][2] * rhs[3],
+          lhs[0][3] * rhs[0] + lhs[1][3] * rhs[1] + lhs[2][3] * rhs[2] + lhs[3][3] * rhs[3]
             });
-        }
+    }
 
-        public static mat4 operator *(mat4 lhs, float s)
-        {
-            return new mat4(new[]
-            {
+    public static mat4 operator *(mat4 lhs, float s)
+    {
+      return new mat4(new[]
+      {
                 lhs[0]*s,
                 lhs[1]*s,
                 lhs[2]*s,
                 lhs[3]*s
             });
-        }
+    }
 
-        #endregion
+    #endregion
 
-        /// <summary>
-        /// The columms of the matrix.
-        /// </summary>
-        private vec4[] cols;
-	}
+    #region comparision
+    /// <summary>
+    /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+    /// The Difference is detected by the different values
+    /// </summary>
+    /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+    /// </returns>
+    public override bool Equals(object obj)
+    {
+      if (obj.GetType() == typeof(mat4))
+      {
+        var mat = (mat4)obj;
+        if (mat[0] == this[0] && mat[1] == this[1] && mat[2] == this[2] && mat[3] == this[3])
+          return true;
+      }
+
+      return false;
+    }
+    /// <summary>
+    /// Implements the operator ==.
+    /// </summary>
+    /// <param name="m1">The first Matrix.</param>
+    /// <param name="m2">The second Matrix.</param>
+    /// <returns>
+    /// The result of the operator.
+    /// </returns>
+    public static bool operator ==(mat4 m1, mat4 m2)
+    {
+      return m1.Equals(m2);
+    }
+
+    /// <summary>
+    /// Implements the operator !=.
+    /// </summary>
+    /// <param name="m1">The first Matrix.</param>
+    /// <param name="m2">The second Matrix.</param>
+    /// <returns>
+    /// The result of the operator.
+    /// </returns>
+    public static bool operator !=(mat4 m1, mat4 m2)
+    {
+      return !m1.Equals(m2);
+    }
+    #endregion
+
+    /// <summary>
+    /// The columms of the matrix.
+    /// </summary>
+    private vec4[] cols;
+  }
 }

--- a/source/GlmNet/GlmNet/mat4.cs
+++ b/source/GlmNet/GlmNet/mat4.cs
@@ -223,6 +223,17 @@ namespace GlmNet
     {
       return !m1.Equals(m2);
     }
+
+    /// <summary>
+    /// Returns a hash code for this instance.
+    /// </summary>
+    /// <returns>
+    /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+    /// </returns>
+    public override int GetHashCode()
+    {
+      return this[0].GetHashCode() ^ this[1].GetHashCode() ^ this[2].GetHashCode() ^ this[3].GetHashCode();
+    }
     #endregion
 
     /// <summary>

--- a/source/GlmNet/GlmNet/vec2.cs
+++ b/source/GlmNet/GlmNet/vec2.cs
@@ -139,6 +139,17 @@ namespace GlmNet
     {
       return !v1.Equals(v2);
     }
+
+    /// <summary>
+    /// Returns a hash code for this instance.
+    /// </summary>
+    /// <returns>
+    /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+    /// </returns>
+    public override int GetHashCode()
+    {
+      return this.x.GetHashCode() ^ this.y.GetHashCode();
+    }
     #endregion
   }
 }

--- a/source/GlmNet/GlmNet/vec2.cs
+++ b/source/GlmNet/GlmNet/vec2.cs
@@ -1,97 +1,144 @@
 using System;
 
-namespace GlmNet 
+namespace GlmNet
 {
+  /// <summary>
+  /// Represents a two dimensional vector.
+  /// </summary>
+  public struct vec2
+  {
+    public float x;
+    public float y;
+
+    public float this[int index]
+    {
+      get
+      {
+        if (index == 0) return x;
+        else if (index == 1) return y;
+        else throw new Exception("Out of range.");
+      }
+      set
+      {
+        if (index == 0) x = value;
+        else if (index == 1) y = value;
+        else throw new Exception("Out of range.");
+      }
+    }
+
+    public vec2(float s)
+    {
+      x = y = s;
+    }
+
+    public vec2(float x, float y)
+    {
+      this.x = x;
+      this.y = y;
+    }
+
+    public vec2(vec2 v)
+    {
+      this.x = v.x;
+      this.y = v.y;
+    }
+
+    public vec2(vec3 v)
+    {
+      this.x = v.x;
+      this.y = v.y;
+    }
+
+    public static vec2 operator +(vec2 lhs, vec2 rhs)
+    {
+      return new vec2(lhs.x + rhs.x, lhs.y + rhs.y);
+    }
+
+    public static vec2 operator +(vec2 lhs, float rhs)
+    {
+      return new vec2(lhs.x + rhs, lhs.y + rhs);
+    }
+
+    public static vec2 operator -(vec2 lhs, vec2 rhs)
+    {
+      return new vec2(lhs.x - rhs.x, lhs.y - rhs.y);
+    }
+
+    public static vec2 operator -(vec2 lhs, float rhs)
+    {
+      return new vec2(lhs.x - rhs, lhs.y - rhs);
+    }
+
+    public static vec2 operator *(vec2 self, float s)
+    {
+      return new vec2(self.x * s, self.y * s);
+    }
+
+    public static vec2 operator *(float lhs, vec2 rhs)
+    {
+      return new vec2(rhs.x * lhs, rhs.y * lhs);
+    }
+
+    public static vec2 operator *(vec2 lhs, vec2 rhs)
+    {
+      return new vec2(rhs.x * lhs.x, rhs.y * lhs.y);
+    }
+
+    public static vec2 operator /(vec2 lhs, float rhs)
+    {
+      return new vec2(lhs.x / rhs, lhs.y / rhs);
+    }
+
+    public float[] to_array()
+    {
+      return new[] { x, y };
+    }
+
+    #region comparision
     /// <summary>
-    /// Represents a two dimensional vector.
+    /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+    /// The Difference is detected by the different values
     /// </summary>
-	public struct vec2
-	{
-		public float x;
-		public float y;
+    /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+    /// </returns>
+    public override bool Equals(object obj)
+    {
+      if (obj.GetType() == typeof(vec2))
+      {
+        var vec = (vec2)obj;
+        if (this.x == vec.x && this.y == vec.y)
+          return true;
+      }
 
-		public float this[int index]
-		{
-			get 
-			{
-				if(index == 0) return x;
-				else if(index == 1) return y;
-                else throw new Exception("Out of range.");
-			}
-			set 
-			{
-				if(index == 0) x = value;
-                else if (index == 1) y = value;
-                else throw new Exception("Out of range.");
-			}
-		}
+      return false;
+    }
+    /// <summary>
+    /// Implements the operator ==.
+    /// </summary>
+    /// <param name="v1">The first Vector.</param>
+    /// <param name="v2">The second Vector.</param>
+    /// <returns>
+    /// The result of the operator.
+    /// </returns>
+    public static bool operator ==(vec2 v1, vec2 v2)
+    {
+      return v1.Equals(v2);
+    }
 
-		public vec2(float s)
-		{
-			x = y = s;
-		}
-
-		public vec2(float x, float y)
-		{
-			this.x = x;
-			this.y = y;
-		}
-
-        public vec2(vec2 v)
-        {
-            this.x = v.x;
-            this.y = v.y;
-        }
-
-        public vec2(vec3 v)
-        {
-            this.x = v.x;
-            this.y = v.y;
-        }
-		
-		public static vec2 operator + (vec2 lhs, vec2 rhs)
-		{
-			return new vec2(lhs.x + rhs.x, lhs.y + rhs.y);
-		}
-
-        public static vec2 operator +(vec2 lhs, float rhs)
-        {
-            return new vec2(lhs.x + rhs, lhs.y + rhs);
-        }
-
-        public static vec2 operator -(vec2 lhs, vec2 rhs)
-        {
-            return new vec2(lhs.x - rhs.x, lhs.y - rhs.y);
-        }
-
-        public static vec2 operator - (vec2 lhs, float rhs)
-        {
-            return new vec2(lhs.x - rhs, lhs.y - rhs);
-        }
-
-        public static vec2 operator *(vec2 self, float s)
-		{
-			return new vec2(self.x * s, self.y * s);
-		}
-
-        public static vec2 operator *(float lhs, vec2 rhs)
-        {
-            return new vec2(rhs.x * lhs, rhs.y * lhs);
-        }
-
-        public static vec2 operator * (vec2 lhs, vec2 rhs)
-        {
-            return new vec2(rhs.x * lhs.x, rhs.y * lhs.y);
-        }
-
-        public static vec2 operator /(vec2 lhs, float rhs)
-        {
-            return new vec2(lhs.x / rhs, lhs.y / rhs);
-        }
-
-        public float[] to_array()
-        {
-            return new[] { x, y };
-        }
-	}
+    /// <summary>
+    /// Implements the operator !=.
+    /// </summary>
+    /// <param name="v1">The first Vector.</param>
+    /// <param name="v2">The second Vector.</param>
+    /// <returns>
+    /// The result of the operator.
+    /// </returns>
+    public static bool operator !=(vec2 v1, vec2 v2)
+    {
+      return !v1.Equals(v2);
+    }
+    #endregion
+  }
 }

--- a/source/GlmNet/GlmNet/vec3.cs
+++ b/source/GlmNet/GlmNet/vec3.cs
@@ -151,6 +151,17 @@ namespace GlmNet
     {
       return !v1.Equals(v2);
     }
+
+    /// <summary>
+    /// Returns a hash code for this instance.
+    /// </summary>
+    /// <returns>
+    /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+    /// </returns>
+    public override int GetHashCode()
+    {
+      return this.x.GetHashCode() ^ this.y.GetHashCode() ^ this.z.GetHashCode();
+    }
     #endregion
   }
 }

--- a/source/GlmNet/GlmNet/vec3.cs
+++ b/source/GlmNet/GlmNet/vec3.cs
@@ -2,108 +2,155 @@ using System;
 
 namespace GlmNet
 {
+  /// <summary>
+  /// Represents a three dimensional vector.
+  /// </summary>
+  public struct vec3
+  {
+    public float x;
+    public float y;
+    public float z;
+
+    public float this[int index]
+    {
+      get
+      {
+        if (index == 0) return x;
+        else if (index == 1) return y;
+        else if (index == 2) return z;
+        else throw new Exception("Out of range.");
+      }
+      set
+      {
+        if (index == 0) x = value;
+        else if (index == 1) y = value;
+        else if (index == 2) z = value;
+        else throw new Exception("Out of range.");
+      }
+    }
+
+    public vec3(float s)
+    {
+      x = y = z = s;
+    }
+
+    public vec3(float x, float y, float z)
+    {
+      this.x = x;
+      this.y = y;
+      this.z = z;
+    }
+
+    public vec3(vec3 v)
+    {
+      this.x = v.x;
+      this.y = v.y;
+      this.z = v.z;
+    }
+
+    public vec3(vec4 v)
+    {
+      this.x = v.x;
+      this.y = v.y;
+      this.z = v.z;
+    }
+
+    public vec3(vec2 xy, float z)
+    {
+      this.x = xy.x;
+      this.y = xy.y;
+      this.z = z;
+    }
+
+    public static vec3 operator +(vec3 lhs, vec3 rhs)
+    {
+      return new vec3(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z);
+    }
+
+    public static vec3 operator +(vec3 lhs, float rhs)
+    {
+      return new vec3(lhs.x + rhs, lhs.y + rhs, lhs.z + rhs);
+    }
+
+    public static vec3 operator -(vec3 lhs, vec3 rhs)
+    {
+      return new vec3(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z);
+    }
+
+    public static vec3 operator -(vec3 lhs, float rhs)
+    {
+      return new vec3(lhs.x - rhs, lhs.y - rhs, lhs.z - rhs);
+    }
+
+    public static vec3 operator *(vec3 self, float s)
+    {
+      return new vec3(self.x * s, self.y * s, self.z * s);
+    }
+    public static vec3 operator *(float lhs, vec3 rhs)
+    {
+      return new vec3(rhs.x * lhs, rhs.y * lhs, rhs.z * lhs);
+    }
+
+    public static vec3 operator /(vec3 lhs, float rhs)
+    {
+      return new vec3(lhs.x / rhs, lhs.y / rhs, lhs.z / rhs);
+    }
+
+    public static vec3 operator *(vec3 lhs, vec3 rhs)
+    {
+      return new vec3(rhs.x * lhs.x, rhs.y * lhs.y, rhs.z * lhs.z);
+    }
+
+    public float[] to_array()
+    {
+      return new[] { x, y, z };
+    }
+
+    #region comparision
     /// <summary>
-    /// Represents a three dimensional vector.
+    /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+    /// The Difference is detected by the different values
     /// </summary>
-	public struct vec3
-	{
-		public float x;
-		public float y;
-		public float z;
+    /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+    /// </returns>
+    public override bool Equals(object obj)
+    {
+      if (obj.GetType() == typeof(vec3))
+      {
+        var vec = (vec3)obj;
+        if (this.x == vec.x && this.y == vec.y && this.z == vec.z)
+          return true;
+      }
 
-		public float this[int index]
-		{
-			get 
-			{
-				if(index == 0) return x;
-				else if(index == 1) return y;
-				else if(index == 2) return z;
-                else throw new Exception("Out of range.");
-			}
-			set 
-			{
-				if(index == 0) x = value;
-                else if (index == 1) y = value;
-                else if (index == 2) z = value;
-                else throw new Exception("Out of range.");
-			}
-		}
+      return false;
+    }
+    /// <summary>
+    /// Implements the operator ==.
+    /// </summary>
+    /// <param name="v1">The first Vector.</param>
+    /// <param name="v2">The second Vector.</param>
+    /// <returns>
+    /// The result of the operator.
+    /// </returns>
+    public static bool operator ==(vec3 v1, vec3 v2)
+    {
+      return v1.Equals(v2);
+    }
 
-		public vec3(float s)
-		{
-			x = y = z = s;
-		}
-
-		public vec3(float x, float y, float z)
-		{
-			this.x = x;
-			this.y = y;
-            this.z = z;
-		}
-
-        public vec3(vec3 v)
-        {
-            this.x = v.x;
-            this.y = v.y;
-            this.z = v.z;
-        }
-
-        public vec3(vec4 v)
-        {
-            this.x = v.x;
-            this.y = v.y;
-            this.z = v.z; 
-        }
-
-        public vec3(vec2 xy, float z)
-        {
-            this.x = xy.x;
-            this.y = xy.y;
-            this.z = z;
-        }
-		
-		public static vec3 operator + (vec3 lhs, vec3 rhs)
-		{
-			return new vec3(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z);
-		}
-
-        public static vec3 operator +(vec3 lhs, float rhs)
-        {
-            return new vec3(lhs.x + rhs, lhs.y + rhs, lhs.z + rhs);
-        }
-
-        public static vec3 operator -(vec3 lhs, vec3 rhs)
-        {
-            return new vec3(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z);
-        }
-
-        public static vec3 operator - (vec3 lhs, float rhs)
-        {
-            return new vec3(lhs.x - rhs, lhs.y - rhs, lhs.z - rhs);
-        }
-
-        public static vec3 operator *(vec3 self, float s)
-		{
-			return new vec3(self.x * s, self.y * s, self.z * s);
-		}
-        public static vec3 operator *(float lhs, vec3 rhs)
-        {
-            return new vec3(rhs.x * lhs, rhs.y * lhs, rhs.z * lhs);
-        }
-
-        public static vec3 operator /(vec3 lhs, float rhs)
-        {
-            return new vec3(lhs.x / rhs, lhs.y / rhs, lhs.z / rhs);
-        }
-
-        public static vec3 operator * (vec3 lhs, vec3 rhs)
-        {
-            return new vec3(rhs.x * lhs.x, rhs.y * lhs.y, rhs.z * lhs.z);
-        }
-
-        public float[] to_array()
-        {
-            return new[] { x, y, z };
-        }
-	}
+    /// <summary>
+    /// Implements the operator !=.
+    /// </summary>
+    /// <param name="v1">The first Vector.</param>
+    /// <param name="v2">The second Vector.</param>
+    /// <returns>
+    /// The result of the operator.
+    /// </returns>
+    public static bool operator !=(vec3 v1, vec3 v2)
+    {
+      return !v1.Equals(v2);
+    }
+    #endregion
+  }
 }

--- a/source/GlmNet/GlmNet/vec4.cs
+++ b/source/GlmNet/GlmNet/vec4.cs
@@ -152,6 +152,17 @@ namespace GlmNet
     {
       return !v1.Equals(v2);
     }
+
+    /// <summary>
+    /// Returns a hash code for this instance.
+    /// </summary>
+    /// <returns>
+    /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+    /// </returns>
+    public override int GetHashCode()
+    {
+      return this.x.GetHashCode() ^ this.y.GetHashCode() ^ this.z.GetHashCode() ^ this.w.GetHashCode();
+    }
     #endregion
   }
 }

--- a/source/GlmNet/GlmNet/vec4.cs
+++ b/source/GlmNet/GlmNet/vec4.cs
@@ -2,108 +2,156 @@ using System;
 
 namespace GlmNet
 {
-    /// <summary>
-    /// Represents a four dimensional vector.
-    /// </summary>
-    public struct vec4
+  /// <summary>
+  /// Represents a four dimensional vector.
+  /// </summary>
+  public struct vec4
+  {
+    public float x;
+    public float y;
+    public float z;
+    public float w;
+
+    public float this[int index]
     {
-        public float x;
-        public float y;
-        public float z;
-        public float w;
-
-        public float this[int index]
-        {
-            get
-            {
-                if (index == 0) return x;
-                else if (index == 1) return y;
-                else if (index == 2) return z;
-                else if (index == 3) return w;
-                else throw new Exception("Out of range.");
-            }
-            set
-            {
-                if (index == 0) x = value;
-                else if (index == 1) y = value;
-                else if (index == 2) z = value;
-                else if (index == 3) w = value;
-                else throw new Exception("Out of range.");
-            }
-        }
-
-        public vec4(float s)
-        {
-            x = y = z = w = s;
-        }
-
-        public vec4(float x, float y, float z, float w)
-        {
-            this.x = x;
-            this.y = y;
-            this.z = z;
-            this.w = w;
-        }
-
-        public vec4(vec4 v)
-        {
-            this.x = v.x;
-            this.y = v.y;
-            this.z = v.z;
-            this.w = v.w;
-        }
-
-        public vec4(vec3 xyz, float w)
-        {
-            this.x = xyz.x;
-            this.y = xyz.y;
-            this.z = xyz.z;
-            this.w = w;
-        }
-
-        public static vec4 operator + (vec4 lhs, vec4 rhs)
-        {
-            return new vec4(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z, lhs.w + rhs.w);
-        }
-
-        public static vec4 operator +(vec4 lhs, float rhs)
-        {
-            return new vec4(lhs.x + rhs, lhs.y + rhs, lhs.z + rhs, lhs.w + rhs);
-        }
-
-        public static vec4 operator -(vec4 lhs, float rhs)
-        {
-            return new vec4(lhs.x - rhs, lhs.y - rhs, lhs.z - rhs, lhs.w - rhs);
-        }
-
-        public static vec4 operator - (vec4 lhs, vec4 rhs)
-        {
-            return new vec4(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z, lhs.w - rhs.w);
-        }
-
-        public static vec4 operator * (vec4 self, float s)
-        {
-            return new vec4(self.x * s, self.y * s, self.z * s, self.w * s);
-        }
-
-        public static vec4 operator * (float lhs, vec4 rhs)
-        {
-            return new vec4(rhs.x * lhs, rhs.y * lhs, rhs.z * lhs, rhs.w * lhs);
-        }
-
-        public static vec4 operator * (vec4 lhs, vec4 rhs)
-        {
-            return new vec4(rhs.x * lhs.x, rhs.y * lhs.y, rhs.z * lhs.z, rhs.w * lhs.w);
-        }
-
-        public static vec4 operator / (vec4 lhs, float rhs)
-        {
-            return new vec4(lhs.x/rhs, lhs.y/rhs, lhs.z/rhs, lhs.w/rhs);
-        }
-
-        public float[] to_array()
-        {
-            return new[] { x, y, z, w };
-        }
+      get
+      {
+        if (index == 0) return x;
+        else if (index == 1) return y;
+        else if (index == 2) return z;
+        else if (index == 3) return w;
+        else throw new Exception("Out of range.");
+      }
+      set
+      {
+        if (index == 0) x = value;
+        else if (index == 1) y = value;
+        else if (index == 2) z = value;
+        else if (index == 3) w = value;
+        else throw new Exception("Out of range.");
+      }
     }
+
+    public vec4(float s)
+    {
+      x = y = z = w = s;
+    }
+
+    public vec4(float x, float y, float z, float w)
+    {
+      this.x = x;
+      this.y = y;
+      this.z = z;
+      this.w = w;
+    }
+
+    public vec4(vec4 v)
+    {
+      this.x = v.x;
+      this.y = v.y;
+      this.z = v.z;
+      this.w = v.w;
+    }
+
+    public vec4(vec3 xyz, float w)
+    {
+      this.x = xyz.x;
+      this.y = xyz.y;
+      this.z = xyz.z;
+      this.w = w;
+    }
+
+    public static vec4 operator +(vec4 lhs, vec4 rhs)
+    {
+      return new vec4(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z, lhs.w + rhs.w);
+    }
+
+    public static vec4 operator +(vec4 lhs, float rhs)
+    {
+      return new vec4(lhs.x + rhs, lhs.y + rhs, lhs.z + rhs, lhs.w + rhs);
+    }
+
+    public static vec4 operator -(vec4 lhs, float rhs)
+    {
+      return new vec4(lhs.x - rhs, lhs.y - rhs, lhs.z - rhs, lhs.w - rhs);
+    }
+
+    public static vec4 operator -(vec4 lhs, vec4 rhs)
+    {
+      return new vec4(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z, lhs.w - rhs.w);
+    }
+
+    public static vec4 operator *(vec4 self, float s)
+    {
+      return new vec4(self.x * s, self.y * s, self.z * s, self.w * s);
+    }
+
+    public static vec4 operator *(float lhs, vec4 rhs)
+    {
+      return new vec4(rhs.x * lhs, rhs.y * lhs, rhs.z * lhs, rhs.w * lhs);
+    }
+
+    public static vec4 operator *(vec4 lhs, vec4 rhs)
+    {
+      return new vec4(rhs.x * lhs.x, rhs.y * lhs.y, rhs.z * lhs.z, rhs.w * lhs.w);
+    }
+
+    public static vec4 operator /(vec4 lhs, float rhs)
+    {
+      return new vec4(lhs.x / rhs, lhs.y / rhs, lhs.z / rhs, lhs.w / rhs);
+    }
+
+    public float[] to_array()
+    {
+      return new[] { x, y, z, w };
+    }
+
+
+    #region comparision
+    /// <summary>
+    /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+    /// The Difference is detected by the different values
+    /// </summary>
+    /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+    /// </returns>
+    public override bool Equals(object obj)
+    {
+      if (obj.GetType() == typeof(vec4))
+      {
+        var vec = (vec4)obj;
+        if (this.x == vec.x && this.y == vec.y && this.z == vec.z && this.w == vec.w)
+          return true;
+      }
+
+      return false;
+    }
+    /// <summary>
+    /// Implements the operator ==.
+    /// </summary>
+    /// <param name="v1">The first Vector.</param>
+    /// <param name="v2">The second Vector.</param>
+    /// <returns>
+    /// The result of the operator.
+    /// </returns>
+    public static bool operator ==(vec4 v1, vec4 v2)
+    {
+      return v1.Equals(v2);
+    }
+
+    /// <summary>
+    /// Implements the operator !=.
+    /// </summary>
+    /// <param name="v1">The first Vector.</param>
+    /// <param name="v2">The second Vector.</param>
+    /// <returns>
+    /// The result of the operator.
+    /// </returns>
+    public static bool operator !=(vec4 v1, vec4 v2)
+    {
+      return !v1.Equals(v2);
+    }
+    #endregion
+  }
 }

--- a/source/GlmNet/Tests/Tests.csproj
+++ b/source/GlmNet/Tests/Tests.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssertExtensions.cs" />
+    <Compile Include="comparisionTests.cs" />
     <Compile Include="matrix_transformTests.cs" />
     <Compile Include="mat4Tests.cs" />
     <Compile Include="mat3Tests.cs" />
@@ -61,6 +62,9 @@
       <Project>{3C5E3C3A-DB59-4DBC-A195-0427350ECB1C}</Project>
       <Name>GlmNet</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/source/GlmNet/Tests/comparisionTests.cs
+++ b/source/GlmNet/Tests/comparisionTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using GlmNet;
+using NUnit.Framework;
+
+namespace Tests
+{
+  /// <summary>
+  /// General tests for all matrix types.
+  /// </summary>
+  [TestFixture]
+  [Category("Rank 3 Matrices")]
+  class comparisionTests
+  {
+    [Test]
+    public void CheckVectorReferenceEquality()
+    {
+      vec2 v2_1 = new vec2(1, 0);
+      vec2 v2_2 = new vec2(1, 0);
+      vec2 v2_3 = new vec2(0, 0);
+      vec2 v2_1ref = v2_1;
+      v2_1ref.y = 1;
+      Assert.AreEqual(v2_1.GetHashCode(), v2_2.GetHashCode(), "Error Hashcodes are not the Same");
+      Assert.AreNotEqual(v2_1.GetHashCode(), v2_1ref.GetHashCode(), "Error Hashcodes are the Same");
+      Assert.AreNotEqual(v2_1.GetHashCode(), v2_3.GetHashCode(), "Error Hashcodes are the Same");
+
+      vec3 v3_1 = new vec3(1, 0, 1);
+      vec3 v3_2 = new vec3(1, 0, 1);
+      vec3 v3_3 = new vec3(0, 0, 1);
+      vec3 v3_1ref = v3_1;
+      v3_1ref.y = 1;
+
+      Assert.AreEqual(v3_1.GetHashCode(), v3_2.GetHashCode(), "Error Hashcodes are not the Same");
+      Assert.AreNotEqual(v3_1.GetHashCode(), v3_1ref.GetHashCode(), "Error Hashcodes are the Same");
+      Assert.AreNotEqual(v3_1.GetHashCode(), v3_3.GetHashCode(), "Error Hashcodes are the Same");
+
+      vec4 v4_1 = new vec4(1, 0, 1, 1);
+      vec4 v4_2 = new vec4(1, 0, 1, 1);
+      vec4 v4_3 = new vec4(0, 0, 1, 1);
+      vec4 v4_1ref = v4_1;
+      v4_1ref.y = 1;
+
+      Assert.AreEqual(v4_1.GetHashCode(), v4_2.GetHashCode(), "Error Hashcodes are not the Same");
+      Assert.AreNotEqual(v4_1.GetHashCode(), v4_1ref.GetHashCode(), "Error Hashcodes are the Same");
+      Assert.AreNotEqual(v4_1.GetHashCode(), v4_3.GetHashCode(), "Error Hashcodes are the Same");
+    }
+
+    [Test]
+    public void CheckMatrixReferenceEquality()
+    {
+      vec2 v2_1 = new vec2(1, 0);
+      vec2 v2_2 = new vec2(1, 0);
+      vec2 v2_3 = new vec2(0, 0);
+      mat2 m2_1 = new mat2(v2_1, v2_2);
+      mat2 m2_2 = new mat2(v2_1, v2_2);
+      mat2 m2_3 = new mat2(v2_1, v2_3);
+
+      vec3 v3_1 = new vec3(1, 0, 1);
+      vec3 v3_2 = new vec3(1, 0, 1);
+      vec3 v3_3 = new vec3(0, 0, 1);
+      mat3 m3_1 = new mat3(v3_1, v3_2,v3_2);
+      mat3 m3_2 = new mat3(v3_1, v3_2, v3_2);
+      mat3 m3_3 = new mat3(v3_1, v3_2, v3_3);
+
+
+      vec4 v4_1 = new vec4(1, 0, 1, 1);
+      vec4 v4_2 = new vec4(1, 0, 1, 1);
+      vec4 v4_3 = new vec4(0, 0, 1, 1);
+      mat4 m4_1 = new mat4(v4_1, v4_2, v4_2, v4_2);
+      mat4 m4_2 = new mat4(v4_1, v4_2, v4_2, v4_2);
+      mat4 m4_3 = new mat4(v4_1, v4_2, v4_2, v4_3);
+
+      Assert.AreEqual(m2_1.GetHashCode(), m2_2.GetHashCode(), "Error Hashcodes are not the Same");
+      Assert.AreNotEqual(m2_1.GetHashCode(), m2_3.GetHashCode(), "Error Hashcodes are the Same");
+      Assert.AreEqual(m3_1.GetHashCode(), m3_2.GetHashCode(), "Error Hashcodes are not the Same");
+      Assert.AreNotEqual(m3_1.GetHashCode(), m3_3.GetHashCode(), "Error Hashcodes are the Same");
+      Assert.AreEqual(m4_1.GetHashCode(), m4_2.GetHashCode(), "Error Hashcodes are not the Same");
+      Assert.AreNotEqual(m4_1.GetHashCode(), m4_3.GetHashCode(), "Error Hashcodes are the Same");
+    }
+   
+  }
+}


### PR DESCRIPTION
Hi, i tried to implement a comparision between primitive data-types(vec2,3,4 and mat2,3,4).
The types implements new ' ==' and '!='operator, new Equals and a new GetHashCode-function.
This could come to problems with old programs, which make use of reference-equality but valuetypes should be even if the values are the same(new vec2(1,1) ==new vec2(1,1) would be true)
