### PR TITLE
Perspective should return a matrix with its (3,3) entry set to 0.0

### DIFF
--- a/source/GlmNet/GlmNet/geometric.cs
+++ b/source/GlmNet/GlmNet/geometric.cs
@@ -8,33 +8,33 @@ namespace GlmNet
     /// with the real GLM.
     /// </summary>
 // ReSharper disable InconsistentNaming
-	public static partial class glm
-	{
+    public static partial class glm
+    {
         public static vec3 cross(vec3 lhs, vec3 rhs)
         {
             return new vec3(
                 lhs.y * rhs.z - rhs.y * lhs.z,
-			    lhs.z * rhs.x - rhs.z * lhs.x,
-			    lhs.x * rhs.y - rhs.x * lhs.y);
+                lhs.z * rhs.x - rhs.z * lhs.x,
+                lhs.x * rhs.y - rhs.x * lhs.y);
         }
 
         public static float dot(vec2 x, vec2 y)
-		{
+        {
             vec2 tmp = new vec2(x * y);
-			return tmp.x + tmp.y;
-		}
+            return tmp.x + tmp.y;
+        }
 
         public static float dot(vec3 x, vec3 y)
         {
-			vec3 tmp = new vec3(x * y);
-			return tmp.x + tmp.y + tmp.z;
-		}
+            vec3 tmp = new vec3(x * y);
+            return tmp.x + tmp.y + tmp.z;
+        }
 
         public static float dot(vec4 x, vec4 y)
-		{
+        {
             vec4 tmp = new vec4(x * y);
-			return (tmp.x + tmp.y) + (tmp.z + tmp.w);
-		}
+            return (tmp.x + tmp.y) + (tmp.z + tmp.w);
+        }
 
         public static vec2 normalize(vec2 v)
         {

--- a/source/GlmNet/GlmNet/matrix_transform.cs
+++ b/source/GlmNet/GlmNet/matrix_transform.cs
@@ -145,6 +145,7 @@ namespace GlmNet
             result[2, 2] = -(zFar + zNear) / (zFar - zNear);
             result[2, 3] = -1.0f;
             result[3, 2] = -(2.0f * zFar * zNear) / (zFar - zNear);
+            result[3, 3] = 0.0f;
             return result;
         }
 


### PR DESCRIPTION
The glm.perspective() function returns a matrix with its (3,3) entry set to 1. This causes the perspective matrix to influence the camera position:

https://stackoverflow.com/questions/47716997/gllookat-moves-camera-position-when-lookat-is-moved-role-of-projection-matrix

When the (3,3) entry is set to 0.0, everything works fine.