### PR TITLE
Performance improvements

### DIFF
--- a/source/GlmNet/GlmNet/geometric.cs
+++ b/source/GlmNet/GlmNet/geometric.cs
@@ -20,20 +20,17 @@ namespace GlmNet
 
         public static float dot(vec2 x, vec2 y)
         {
-            vec2 tmp = new vec2(x * y);
-            return tmp.x + tmp.y;
+            return x.x * y.x + x.y * y.y;
         }
 
         public static float dot(vec3 x, vec3 y)
         {
-            vec3 tmp = new vec3(x * y);
-            return tmp.x + tmp.y + tmp.z;
+            return x.x * y.x + x.y * y.y + x.z * y.z;
         }
 
         public static float dot(vec4 x, vec4 y)
         {
-            vec4 tmp = new vec4(x * y);
-            return (tmp.x + tmp.y) + (tmp.z + tmp.w);
+            return x.x * y.x + x.y * y.y + x.z * y.z + x.w * y.w;
         }
 
         public static vec2 normalize(vec2 v)

--- a/source/GlmNet/GlmNet/mat2.cs
+++ b/source/GlmNet/GlmNet/mat2.cs
@@ -134,8 +134,8 @@ namespace GlmNet
         public static vec2 operator *(mat2 lhs, vec2 rhs)
         {
             return new vec2(
-                lhs[0, 0] * rhs[0] + lhs[1, 0] * rhs[1],
-                lhs[0, 1] * rhs[0] + lhs[1, 1] * rhs[1]
+                lhs[0, 0] * rhs.x + lhs[1, 0] * rhs.y,
+                lhs[0, 1] * rhs.x + lhs[1, 1] * rhs.y
             );
         }
 
@@ -149,8 +149,8 @@ namespace GlmNet
         {
             return new mat2(new[]
             {
-          lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1],
-          lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1]
+                lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1],
+                lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1]
             });
         }
 

--- a/source/GlmNet/GlmNet/mat2.cs
+++ b/source/GlmNet/GlmNet/mat2.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 
 namespace GlmNet
 {
@@ -115,7 +114,11 @@ namespace GlmNet
         /// <returns></returns>
         public float[] to_array()
         {
-            return cols.SelectMany(v => v.to_array()).ToArray();
+            return new float[] 
+            {
+                cols[0].x, cols[0].y,
+                cols[1].x, cols[1].y
+            };
         }
 
         #endregion

--- a/source/GlmNet/GlmNet/mat3.cs
+++ b/source/GlmNet/GlmNet/mat3.cs
@@ -110,7 +110,12 @@ namespace GlmNet
         /// <returns></returns>
         public float[] to_array()
         {
-            return cols.SelectMany(v => v.to_array()).ToArray();
+            return new float[]
+            {
+                cols[0].x, cols[0].y, cols[0].z,
+                cols[1].x, cols[1].y, cols[1].z,
+                cols[2].x, cols[2].y, cols[2].z
+            };
         }
 
         /// <summary>

--- a/source/GlmNet/GlmNet/mat3.cs
+++ b/source/GlmNet/GlmNet/mat3.cs
@@ -142,9 +142,9 @@ namespace GlmNet
         public static vec3 operator *(mat3 lhs, vec3 rhs)
         {
             return new vec3(
-                lhs[0, 0] * rhs[0] + lhs[1, 0] * rhs[1] + lhs[2, 0] * rhs[2],
-                lhs[0, 1] * rhs[0] + lhs[1, 1] * rhs[1] + lhs[2, 1] * rhs[2],
-                lhs[0, 2] * rhs[0] + lhs[1, 2] * rhs[1] + lhs[2, 2] * rhs[2]
+                lhs[0, 0] * rhs.x + lhs[1, 0] * rhs.y + lhs[2, 0] * rhs.z,
+                lhs[0, 1] * rhs.x + lhs[1, 1] * rhs.y + lhs[2, 1] * rhs.z,
+                lhs[0, 2] * rhs.x + lhs[1, 2] * rhs.y + lhs[2, 2] * rhs.z
             );
         }
 
@@ -158,9 +158,9 @@ namespace GlmNet
         {
             return new mat3(new[]
             {
-          lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1] + lhs[2][0] * rhs[2],
-          lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1] + lhs[2][1] * rhs[2],
-          lhs[0][2] * rhs[0] + lhs[1][2] * rhs[1] + lhs[2][2] * rhs[2]
+                lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1] + lhs[2][0] * rhs[2],
+                lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1] + lhs[2][1] * rhs[2],
+                lhs[0][2] * rhs[0] + lhs[1][2] * rhs[1] + lhs[2][2] * rhs[2]
             });
         }
 

--- a/source/GlmNet/GlmNet/mat4.cs
+++ b/source/GlmNet/GlmNet/mat4.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 
 namespace GlmNet
 {
@@ -113,7 +112,14 @@ namespace GlmNet
         /// <returns></returns>
         public float[] to_array()
         {
-            return cols.SelectMany(v => v.to_array()).ToArray();
+            return new float[]
+           {
+                cols[0].x, cols[0].y, cols[0].z, cols[0].w,
+                cols[1].x, cols[1].y, cols[1].z, cols[1].w,
+                cols[2].x, cols[2].y, cols[2].z, cols[2].w,
+                cols[3].x, cols[3].y, cols[3].z, cols[3].w,
+
+           };
         }
 
         /// <summary>
@@ -179,7 +185,7 @@ namespace GlmNet
         #endregion
 
         #region ToString support
-            
+
         public override string ToString()
         {
             return String.Format(

--- a/source/GlmNet/GlmNet/mat4.cs
+++ b/source/GlmNet/GlmNet/mat4.cs
@@ -147,10 +147,10 @@ namespace GlmNet
         public static vec4 operator *(mat4 lhs, vec4 rhs)
         {
             return new vec4(
-                lhs[0, 0] * rhs[0] + lhs[1, 0] * rhs[1] + lhs[2, 0] * rhs[2] + lhs[3, 0] * rhs[3],
-                lhs[0, 1] * rhs[0] + lhs[1, 1] * rhs[1] + lhs[2, 1] * rhs[2] + lhs[3, 1] * rhs[3],
-                lhs[0, 2] * rhs[0] + lhs[1, 2] * rhs[1] + lhs[2, 2] * rhs[2] + lhs[3, 2] * rhs[3],
-                lhs[0, 3] * rhs[0] + lhs[1, 3] * rhs[1] + lhs[2, 3] * rhs[2] + lhs[3, 3] * rhs[3]
+                lhs[0, 0] * rhs.x + lhs[1, 0] * rhs.y + lhs[2, 0] * rhs.z + lhs[3, 0] * rhs.w,
+                lhs[0, 1] * rhs.x + lhs[1, 1] * rhs.y + lhs[2, 1] * rhs.z + lhs[3, 1] * rhs.w,
+                lhs[0, 2] * rhs.x + lhs[1, 2] * rhs.y + lhs[2, 2] * rhs.z + lhs[3, 2] * rhs.w,
+                lhs[0, 3] * rhs.x + lhs[1, 3] * rhs.y + lhs[2, 3] * rhs.z + lhs[3, 3] * rhs.w
             );
         }
 

--- a/source/GlmNet/GlmNet/matrix_transform.cs
+++ b/source/GlmNet/GlmNet/matrix_transform.cs
@@ -196,13 +196,13 @@ namespace GlmNet
                 return Result; // Error
 
             vec3 Temp = new vec3(
-                ((viewport[2]) - (2f) * (center.x - (viewport[0]))) / delta.x,
-                ((viewport[3]) - (2f) * (center.y - (viewport[1]))) / delta.y,
+                ((viewport.z) - (2f) * (center.x - (viewport.x))) / delta.x,
+                ((viewport.w) - (2f) * (center.y - (viewport.y))) / delta.y,
                 (0f));
 
             // Translate and scale the picked region to the entire window
             Result = translate(Result, Temp);
-            return scale(Result, new vec3((viewport[2]) / delta.x, (viewport[3]) / delta.y, (1)));
+            return scale(Result, new vec3((viewport.z) / delta.x, (viewport.w) / delta.y, (1)));
         }
 
         /// <summary>
@@ -214,7 +214,6 @@ namespace GlmNet
         /// <param name="viewport">The viewport.</param>
         /// <returns></returns>
         public static vec3 project(vec3 obj, mat4 model, mat4 proj, vec4 viewport)
-
         {
             vec4 tmp = new vec4(obj, (1f));
             tmp = model * tmp;
@@ -222,10 +221,11 @@ namespace GlmNet
 
             tmp /= tmp.w;
             tmp = tmp * 0.5f + 0.5f;
-            tmp[0] = tmp[0] * viewport[2] + viewport[0];
-            tmp[1] = tmp[1] * viewport[3] + viewport[1];
+            obj.x = tmp.x * viewport.z + viewport.x;
+            obj.y = tmp.y * viewport.w + viewport.y;
+            obj.z = tmp.z;
 
-            return new vec3(tmp.x, tmp.y, tmp.z);
+            return obj;
         }
 
         /// <summary>
@@ -281,9 +281,9 @@ namespace GlmNet
         public static mat4 scale(mat4 m, vec3 v)
         {
             mat4 result = m;
-            result[0] = m[0] * v[0];
-            result[1] = m[1] * v[1];
-            result[2] = m[2] * v[2];
+            result[0] = m[0] * v.x;
+            result[1] = m[1] * v.y;
+            result[2] = m[2] * v.z;
             result[3] = m[3];
             return result;
         }
@@ -297,7 +297,7 @@ namespace GlmNet
         public static mat4 translate(mat4 m, vec3 v)
         {
             mat4 result = m;
-            result[3] = m[0] * v[0] + m[1] * v[1] + m[2] * v[2] + m[3];
+            result[3] = m[0] * v.x + m[1] * v.y + m[2] * v.z + m[3];
             return result;
         }
 
@@ -339,8 +339,8 @@ namespace GlmNet
             mat4 Inverse = glm.inverse(proj * model);
 
             vec4 tmp = new vec4(win, (1f));
-            tmp.x = (tmp.x - (viewport[0])) / (viewport[2]);
-            tmp.y = (tmp.y - (viewport[1])) / (viewport[3]);
+            tmp.x = (tmp.x - (viewport.x)) / (viewport.z);
+            tmp.y = (tmp.y - (viewport.y)) / (viewport.w);
             tmp = tmp * (2f) - (1f);
 
             vec4 obj = Inverse * tmp;


### PR DESCRIPTION
The usage of LINQ slowed down the conversion from matrices to arrays by a lot. I got massive performance improvements by simply getting rid of them (I had several thousand calls of to_array per frame in my render engine). The code I replaced LINQ with is really not complicated and I see absolutely no reason to use LINQ here.

Some vector operations were allocating new vector object while the operations can be performed without them as well so I removed them.

I also replaced a few index accesses on vectors with direct variable access which should be quite a bit faster as well since it avoids all the branches. The index operator really only is useful for iterating over the values.